### PR TITLE
Fix logfile creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The first time you run etm it will create, if necessary, the following:
 
     ~/.etm/
     ~/.etm/etmtk.cfg
+    ~/.etm/etmtk_log.txt
     ~/.etm/data/
 
 

--- a/etmTk/data.py
+++ b/etmTk/data.py
@@ -38,9 +38,8 @@ def setup_logging(level, etmdir=None):
     if os.path.isdir(etmdir):
         logfile = os.path.normpath(os.path.abspath(os.path.join(etmdir, "etmtk_log.txt")))
         if not os.path.isfile(logfile):
-            fo = codecs.open(fp, 'w', dfile_encoding)
-            fo.write("")
-            fo.close()
+            open(logfile, 'a').close()
+
         config = {'disable_existing_loggers': False,
                   'formatters': {'simple': {
                       'format': '--- %(asctime)s - %(levelname)s - %(module)s.%(funcName)s\n    %(message)s'}},


### PR DESCRIPTION
If etmtk_log.txt does not already exist, etm would try to create it, but would
fail with NameErrors on fp and dfile_encoding.  Since encoding doesn't matter
when we're just creating an empty file, replace it with a short call to open.
Also note in the README that this file is created as part of initialization.
