### PR TITLE
Fix broken Tk Treeview item fg/bg colors

### DIFF
--- a/etmTk/view.py
+++ b/etmTk/view.py
@@ -216,6 +216,13 @@ class App(Tk):
 
         style = self.options['style']
         s = ttk.Style()
+
+        # Fix broken tkinter Treeview colors for Python3.7+
+        # Fix source: https://bugs.python.org/issue36468
+        def fixed_map(option):
+            return [elm for elm in s.map('Treeview', query_opt=option) if elm[:2] != ('!disabled', '!selected')]
+        s.map('Treeview', foreground=fixed_map('foreground'), background=fixed_map('background'))
+
         styles = s.theme_names()
         if style in styles:
             logger.info("using style {0}".format(style))


### PR DESCRIPTION
Since Python3.7.3, there has appeared an issue with Tk Treeview item colors. A workaround exists which can be found at: https://bugs.python.org/issue36468